### PR TITLE
Node Versioning semver change.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "git://github.com/reconbot/node-phaxio.git"
   },
   "engines": {
-    "node": "^4.4.x",
+    "node": ">=4.4.x",
     "npm": "^3.8.x"
   },
   "main": "./src/phaxio.js",


### PR DESCRIPTION
When trying to install `phaxio-promise` with `yarn` and node version 5 or higher, the following error is thrown:

`error phaxio-promise@0.2.0: The engine "node" is incompatible with this module. Expected version "^4.4.x".`

This PR fixes that, and accurately reflects that `phaxio-promise` works on modern versions of node.